### PR TITLE
[TAO-8093] ACT: Client Diagnostic Tool doesn't work.

### DIFF
--- a/config/default/clientDiag.conf.php
+++ b/config/default/clientDiag.conf.php
@@ -21,5 +21,7 @@
  * Default client diag config
  */
 return array(
-    'extension' => 'ltiClientdiag',
+    'diagnostic' => array(
+        'extension' => 'ltiClientdiag',
+    )
 );

--- a/controller/Diagnostic.php
+++ b/controller/Diagnostic.php
@@ -103,7 +103,7 @@ class Diagnostic extends DiagnosticController
      */
     protected function loadConfig()
     {
-        $config = array_merge(
+        $config = array_merge_recursive(
             parent::loadConfig(),
             \common_ext_ExtensionsManager::singleton()->getExtensionById('ltiClientdiag')->getConfig('clientDiag')
         );

--- a/manifest.php
+++ b/manifest.php
@@ -28,11 +28,11 @@ return [
     'label' => 'LTI Client Diagnostic',
     'description' => 'Grants access to the client diagnostic functionality using LTI',
     'license' => 'GPL-2.0',
-    'version' => '2.0.1',
+    'version' => '2.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'taoLti' => '>=7.0.0',
-        'taoClientDiagnostic' => '>=3.0.0'
+        'taoClientDiagnostic' => '>=6.0.1'
     ],
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#ltiClientdiagManager',
     'acl' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -76,5 +76,19 @@ class Updater extends \common_ext_ExtensionUpdater
 
         $this->skip('1.3.0', '2.0.1');
 
+        if ($this->isVersion('2.0.1')) {
+            // Update clientDiag.conf.php
+            $extension = $this->getServiceManager()
+                ->get(\common_ext_ExtensionsManager::SERVICE_ID)
+                ->getExtensionById('ltiClientdiag');
+            $oldClientDiagConfig = $extension->getConfig('clientDiag');
+
+            $extension->setConfig('clientDiag', [
+                'diagnostic' => $oldClientDiagConfig,
+            ]);
+
+            $this->setVersion('2.0.2');
+        }
+
     }
 }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8093
 
Fix issues related to update of taoClientDiagnostic extension config
 
#### Steps to reproduce  (for bugs)
To reproduce the issue please follow the steps described in the ticket
  
#### How to test
1.
- Install new ACT instance from develop branch
- Switch all affected extensions to PRs branches
- Update ACT instance
- Check that ltiClientDiag extension works without issues

2.
- Install new ACT instance from PRs branches
- Check that ltiClientDiag extension works without issues

  
#### Dependencies
   
Requires :
 - [ ] https://github.com/oat-sa/extension-tao-clientdiag/pull/234